### PR TITLE
Add new Game Entity component system hashes

### DIFF
--- a/hashes/lol/hashes.binfields.txt
+++ b/hashes/lol/hashes.binfields.txt
@@ -663,6 +663,7 @@ b3711c47 CHECK
 141669d6 CameoPortraitIcon
 dc2df35f CameoPortraitRegion
 b186288e CameoTooltipAnchor
+9ebe984e Camera
 d65e723c CameraAnimation
 6495fab8 CameraBone
 d00dda71 CameraBoundsAsPercentageOfMapBounds
@@ -809,6 +810,7 @@ a756b81c ChaosTeamIdentity
 156a6d60 CharacterBannerSkinName
 00243921 CharacterFadeInstance
 8390f398 CharacterList
+035431c5 CharacterMesh
 38022a93 CharacterName
 ec182a7b CharacterNameOverride
 26444773 CharacterOffset
@@ -2528,6 +2530,7 @@ e70b7d23 LabelTemplate
 ca0e79b5 LabelTraKey
 bdda148a Labels
 6506aa85 Labs
+e87dbba2 LaneDefinition
 ec94a978 LargeLoadoutsIcon
 56a33fe1 LargeSlots
 ceee9c73 LargeSquare
@@ -2638,6 +2641,8 @@ f30a6eea LevelUpUiData
 a147b6ea Levels
 d628825f LifeStealAndVamp
 055a541d LifetimeComponent
+e29d1e2f Light
+0fb30c27 LightRegion
 ea4e5cc8 LightgridBounceFalloffDistance
 22d24a9a LightgridOverallScale
 2f3b5471 LightgridScaleBounceContribution
@@ -3202,6 +3207,7 @@ a97376aa NavGridOverlay
 f7197db9 NavGridPath
 4a989cc9 NavHeaderScene
 365ff9f6 NavMeshFileName
+301dab05 NavRegionDef
 6d13b0ea NavigationGridOverlays
 0dc0043a NavigationGroup
 40d97d44 NavigationText
@@ -3213,6 +3219,7 @@ c77c4866 NeedsPushToTalkEnabled
 757cbb5b Negate
 ae0964fb NegativeBountyConfig
 4e1babb4 NegativeBuffs
+7e5978a5 NeutralCamp
 08991dc1 NeutralTimerStateManager
 763cc4ab NeutralTimerStates
 4c7bb73e NeutralTimers

--- a/hashes/lol/hashes.binfields.txt
+++ b/hashes/lol/hashes.binfields.txt
@@ -83,6 +83,7 @@ a55e849c AddTextSizeToHitRegion
 487e35dd AddToTeamFailureSound
 ddbea054 AddedCalculationParts
 432547b6 AdditionalBarTypes
+7b9718c4 AdditionalChannels
 51ea4860 AdditionalLevelUpLinks
 073a7e91 AdditionalMeterSkins
 3f1b156a AdditionalPipSpacerTypes
@@ -147,6 +148,7 @@ b7024f99 AllowSingleItemSelection
 359dd774 AllowedStages
 4bf41a2c AllyFrame
 372a1376 AllyGem
+44a9a2c2 AlphaChannel
 9c5124c0 AlphaOutWhileUntargetable
 29de782e AltLayoutRegion
 79c702f3 AlwaysRespawnWithOffset
@@ -484,6 +486,7 @@ a2734825 Blinded
 98ba36f3 BlockInputEvents
 44b4862a BlockPlayerIcon
 c967b34f Bloodwell
+44956bbc BlueChannel
 8c678ff0 BlueSkin
 25834918 BlueTeamElementSelectedColor
 df925021 BlueTeamElementUnselectedColor
@@ -859,6 +862,7 @@ d4f40efa ChestBackgroundAssetVfx
 ed51e4eb ChestTimingOffset
 8afbdca6 ChildAnimDelaySwitchTime
 8e5e6618 ChildClipName
+56849af8 ChildComponent
 67a9c9d2 Children
 e35a50c8 ChoiceDescription
 9df91392 ChosenBadge
@@ -887,6 +891,7 @@ b18e5e08 ClearAllButtonDefinition
 0a004a31 ClearAllTrakey
 c6e9fbea ClearButton
 c74c762c ClearButtonTemplate
+9a1a92b5 ClearColor
 cea34a2c ClearUndoHistoryOnActivate
 cfe20df6 ClickAbsorbingRegionElement
 9fba55f7 ClickData
@@ -1987,6 +1992,7 @@ df684997 GenericIcon
 25b7e625 GenericLarge
 c3b8b9d4 GenericLargeUncolored
 ea961f89 GenericSmall
+0f32e8cc GeometryComponent
 84a64914 GetAcquisitionRangeUsesAttackRange
 4eb5a788 GetPocClampBufferTrapezoid
 79b2d636 GetPocClampTrapezoid
@@ -2018,6 +2024,7 @@ f3eb96d4 GoldText
 2875fcd2 GravesSmall
 d209ff45 Gravity
 81bc04be GreaterThan
+7ae6487f GreenChannel
 f614d04b GreyedTimerText
 af871a91 Grid
 f5e9f0c5 GridButtonData
@@ -2630,6 +2637,7 @@ f30a6eea LevelUpUiData
 8a436b27 LevelUpVfxGroup
 a147b6ea Levels
 d628825f LifeStealAndVamp
+055a541d LifetimeComponent
 ea4e5cc8 LightgridBounceFalloffDistance
 22d24a9a LightgridOverallScale
 2f3b5471 LightgridScaleBounceContribution
@@ -3245,6 +3253,7 @@ c5ec44db NoContentTitleTraKey
 ada7afdb None
 a8e4f979 NormalCastButtonPos
 7af87ddd NormalItemButton
+8c6b1234 NormalOffsetBias
 53fa9427 NormalSkin
 ce79296c Normalize
 edec2e12 NotFacingMovementWhenCasting
@@ -3953,6 +3962,7 @@ eae44d07 Rect
 a27d84d4 RectSourcePSDFilename
 6240fc33 RectSourceResolutionHeight
 df3f6504 RectSourceResolutionWidth
+2b6a031f RedChannel
 7f8fc16d RedSkin
 0c263131 RedTeamElementSelectedColor
 af1fcb6f RedeTeamElementUnselectedColor
@@ -4175,6 +4185,7 @@ fe57aadd RotationalShopItemData
 eb302eba RoundDamage
 4b7703b3 RoundLabel
 352a241c RoundLabelTra
+3e2cdad7 RoundListOptions
 a1a8bf5a RoundNumber
 a607bda2 RoundPlacement
 d9c91ded RoundStateIcon
@@ -4360,6 +4371,7 @@ c719768a SeraphineStyleLarge
 68c3f356 SetManually
 278d2a22 SetOverrideAttackDelay
 1a28d722 SetsCompletedToBackgroundEffects
+23e7082c ShaderParameters
 897eefc2 ShadingModel
 d14e6310 ShadowBias
 791b47a2 ShadowItemButton
@@ -5057,6 +5069,7 @@ d516b033 TextureMini
 b311d4ef TextureName
 17c543dc TextureOverride
 1a898c7d TextureOverrides
+b6d29fce TextureResolution
 489a16f5 TextureToOverride
 e2fed020 TextureUs
 c22d5164 TextureUvs
@@ -5648,6 +5661,7 @@ f00a885b VerticalJustification
 19743deb VfxAlignmentTake
 6b1b4e23 VfxBrighterInFowAsDisabledFow
 9664b764 VfxCollapsedToExpanded
+1cf263eb VfxComponents
 8462f4a1 VfxEnableTime
 8efaff74 VfxExpandedToCollapsed
 23e8f406 VfxGroup
@@ -5780,6 +5794,9 @@ de708c93 abilitySlotCC
 233072a6 activatedBuffName
 3b391274 add
 ee172090 additionalCharacters
+82ab734b addressModeU
+83ab74de addressModeV
+84ab7671 addressModeW
 111ec6d2 addressU
 101ec53f addressV
 0f1ec3ac addressW
@@ -6133,6 +6150,7 @@ e2b5d80d damagePerLevelModifiable
 397db5c1 damageTagDefinition
 2eedede5 darkColoration
 d872e2a5 data
+08f782f8 dataBuffers
 b4b13a2d dataType
 bd28bd4d death
 5d19c62e deathEventListeningRadius
@@ -8661,6 +8679,7 @@ b1e439af maxAlpha
 40656ce7 maxAngleCos
 166e1615 maxAngleFadeCos
 070b4922 maxAngleRangeFactor
+b6887851 maxAnisotropy
 e6915cf6 maxDistance
 80f63e4f maxIndex
 53d4cc0f maxInstances
@@ -8725,6 +8744,8 @@ b2f634ab minimumDisplayedRange
 9d8131ba minimumPracticeToolScale
 20b578ca minionFlags
 fe195c64 minionScoreValue
+650eb4bb mipFilter
+21bafb31 mipLodBias
 619396ba mipped
 6563bee8 miscRenderFlags
 1985fb4b missileGroupSpawners
@@ -8981,6 +9002,7 @@ faa9aa58 rotationIsEnabled
 01028ccd rtpcName
 02e7fb4c samplerName
 0a6f0eb5 samplerValues
+e0540d74 samplers
 82971c71 scale
 d4e17a53 scale0
 d3e178c0 scale1
@@ -9051,6 +9073,8 @@ dee4f011 shakeFrequency
 e69cdc70 shakeReferenceResolution
 91193f20 shakeTriggerPercent
 9dc3d926 shape
+b26be7bf sharedDataBuffers
+a90a8855 sharedSamplers
 7d94eaf6 shortName
 cf3ba016 shouldAlwaysTargetEnemy
 9a863eb9 shouldRandomizeIdleAnimPhase

--- a/hashes/lol/hashes.binfields.txt
+++ b/hashes/lol/hashes.binfields.txt
@@ -4325,6 +4325,7 @@ a71279f3 SelectionOutlineTemplate
 5d578c98 SelectionRotatingIcon
 011381e3 SelectionScene
 8a3aa07b SelectivelyClearActiveSpellOnTargetInRange
+33fae3fc Selector
 aaf62a62 SelectorButtonTemplate
 c73c4213 SelectorMenu
 fa132c11 SelectorMovement
@@ -4729,6 +4730,7 @@ ae8a302d StatStoneIcon
 1545ddef StateEventId
 fd81566b StateIndicatorList
 fce96f95 StateLogicEventSignalId
+2f60f64e StateMachineDef
 9097411f StateScenes
 6d4da2ea StaticIcon
 d50c7c8a StaticTexture
@@ -5952,6 +5954,7 @@ d844ed3d beamParticleDefinition
 6b89d541 beginIn
 f314d542 beginOut
 a0f69e3c behaviors
+c914b02b bevel
 ca406316 bindWeight
 a24dc16e birthAcceleration
 83cdeaa1 birthColor
@@ -6278,6 +6281,7 @@ f365a945 enemyChampSpecificHealthSuffix
 618581ea enemyTooltip
 6246290c enlargeSize
 c245e974 enlargeTime
+53ec22d9 envMesh
 a8a3777b environmentSHIrradiance
 5ee3c453 epicness
 39ad7a1b equipButton
@@ -6513,6 +6517,7 @@ b9516a6f importance
 f729e184 incrementalPurchase
 40c6c39e indicatorType
 cd8310f1 inertia
+8f59d48c inheritedTags
 98c52469 inherits
 09dbf7c7 initialDensityMapAsset
 382825a9 initialSubmeshMouseOversToHide
@@ -8774,6 +8779,7 @@ f506c7e6 multiplier
 566f3406 nameOverride
 1f6232c0 nameTranslationKey
 a32e6947 navGridFileName
+30e1280e navRegion
 05991009 nearClip
 39c8d824 nearsight
 8c4b1ad8 neutral
@@ -9073,6 +9079,7 @@ dee4f011 shakeFrequency
 e69cdc70 shakeReferenceResolution
 91193f20 shakeTriggerPercent
 9dc3d926 shape
+f43f2e26 shapeData
 b26be7bf sharedDataBuffers
 a90a8855 sharedSamplers
 7d94eaf6 shortName
@@ -9391,6 +9398,7 @@ a0c70f80 visibilityComponent
 0dc74f32 visibilityMode
 fd01a9d3 visibilityRadius
 b27bdbb2 visibleSelectionName
+0ffde771 visionRegion
 28412914 voBank
 11f6313b voBankAssetPath
 99f78103 voBankPath

--- a/hashes/lol/hashes.bintypes.txt
+++ b/hashes/lol/hashes.bintypes.txt
@@ -778,6 +778,7 @@ a64d5210 EngineFeatureToggles
 92bb5993 EnterFOWVisibility
 c8681d90 EnterFOWVisibilityInstance
 f16fc504 EnterFOWVisibilitySpec
+1568b7bc EntityStateMachine
 e5a9c94a EnvironmentBakedLightingShadingModel
 765f0c19 EnvironmentPbrShadingModel
 0ed05709 EnvironmentUnlitShadingModel
@@ -986,6 +987,8 @@ bc409284 GameCalculation
 e9ced584 GameCalculationConditional
 070e3593 GameCalculationModified
 e4564452 GameComponentData
+0760ad40 GameEntity
+40a9c74a GameEntityTemplate
 e343b9b0 GameFontDescription
 4ad4766b GameFontDescriptionInstance
 69bb6e6a GameModeAutoItemPurchasingConfig
@@ -2318,6 +2321,7 @@ b574b3af RegionBoundary
 2da963dd RegionBoundaryConfig
 a4290ed0 RegionDataBase
 6ed61477 RegionElementData
+d8f395a4 RegionEntityTemplate
 18ca230c RegionGeComponent
 22df6f20 RegionSettings
 9ddb195b RegionSettingsInstance
@@ -3487,6 +3491,7 @@ bfc2e133 VfxEmissionSurfaceData
 01b7cd7d VfxEmitterDefinitionDataInstance
 f4e37e07 VfxEmitterFiltering
 7f70a2b2 VfxEmitterLegacySimple
+1f1f50f2 VfxEntityTemplate
 0a94f3d4 VfxFieldAccelerationDefinitionData
 46f3f2ef VfxFieldAccelerationDefinitionDataInstance
 1a7617fd VfxFieldAttractionDefinitionData

--- a/hashes/lol/hashes.bintypes.txt
+++ b/hashes/lol/hashes.bintypes.txt
@@ -76,6 +76,7 @@ b075bcfd AnimatedBuildingCommon
 7fc1d873 AnimationFractionDynamicMaterialFloatDriver
 2b579f70 AnimationFractionDynamicMaterialFloatDriverInstance
 6665076c AnimationGeComponent
+bdadb6f3 AnimationGeComponentDef
 f5fb07c7 AnimationGraphData
 322a4094 AnimationGraphDataInstance
 9a4b299d AnimationResourceData
@@ -110,6 +111,7 @@ e6caaf8c AttackEvents
 9c4f3cc3 AttackSpeedParametricUpdater
 2092043f AttackableUnit
 0ae1a932 AttackableUnitGeComponent
+cbe6ced9 AttackableUnitGeComponentDef
 865caeee AudioStatusEvents
 77c4e579 AudioStatusEventsInstance
 3692fac5 AudioSystemDataProperties
@@ -150,6 +152,7 @@ d1ed70fe Barracks
 60bb49c0 BarracksDampener
 f10cf1d9 BarracksDampenerCommon
 63143919 BarracksGeComponent
+f3121b20 BarracksGeComponentDef
 ffb1b62c BarracksLevelController
 8f0c2ed6 BarracksLink
 8129e422 BarracksMinionConfig
@@ -185,6 +188,7 @@ e5a69c70 BasicSpellSlotIntDriver
 e885e978 BerserkTargetingPriorityList
 afb0749d BezierPath
 0f63704f BezierSegment
+1fe89d02 BillboardGeComponentDef
 e1df3f2f BinFileContainer
 cc2ddcc0 BlendData
 505dd936 BlendableClipData
@@ -303,6 +307,7 @@ b60f0432 CharScript
 db69f5cb CharacterInstance
 07c20fe9 CharacterLevelRequirement
 a939f1b6 CharacterLevelRequirementInstance
+747991cb CharacterMeshGeComponentDef
 c6228969 CharacterOverrides
 8ea3ea45 CharacterPassiveData
 fc4f4b05 CharacterPreloadData
@@ -358,6 +363,7 @@ e21083b5 ChildMapVisibilityController
 911cbd12 ChildMissileSiblingRepulsion
 8085e5d1 CinematicBarsViewController
 bafcf76c CinematicCameraGeComponent
+630106f3 CinematicCameraGeComponentDef
 039b5ebc CircleMovement
 a66643e7 CircleMovementInstance
 4a9d1e4f CircleMovementSpec
@@ -607,6 +613,7 @@ ec41779d DamageUnitCheat
 3cebd9da DamageUnitCheatInstance
 2e548aaf DeathEventPriority
 8563543c DeathGeComponent
+f81e16e3 DeathGeComponentDef
 d09acba6 DeathRecapDamageOverview
 7efae6c2 DeathRecapDamagerCondensedList
 75e8f0c1 DeathRecapDamagerDetailedDisplayData
@@ -671,6 +678,7 @@ ceaae805 DoDamage
 a1c2c89f DoubleSidedTipStyle
 0af2666c DragDirection
 b251dcda DragonCampGeComponent
+6f0236d1 DragonCampGeComponentDef
 cd0d7450 DragonUITunables
 03b1c66a DrawAreaList
 42d144f5 DrawFx
@@ -680,6 +688,7 @@ b29e8d11 DrawablePositionLocatorInstance
 2d6bf1a2 DynamicMaterialDef
 8dd0b9dd DynamicMaterialDefInstance
 96974776 DynamicMaterialGeComponent
+ced882fd DynamicMaterialGeComponentDef
 7a12b6a7 DynamicMaterialHelper
 073f6a51 DynamicMaterialParameterDef
 d8670eee DynamicMaterialParameterDefInstance
@@ -690,7 +699,9 @@ ef39fa85 DynamicMaterialStaticSwitch
 21d0c864 DynamicMaterialTextureSwapOption
 3670e03f DynamicMaterialTextureSwapOptionInstance
 c02e8323 DynamicPointLightGeComponent
+1ed8dbf2 DynamicPointLightGeComponentDef
 de1c190d DynamicSpotlightGeComponent
+4e0d6ae4 DynamicSpotlightGeComponentDef
 48b49195 ESportLeagueEntry
 9c1fb3a2 ESportLeagueEntryInstance
 141100a5 ESportTeamEntry
@@ -779,6 +790,7 @@ a64d5210 EngineFeatureToggles
 c8681d90 EnterFOWVisibilityInstance
 f16fc504 EnterFOWVisibilitySpec
 1568b7bc EntityStateMachine
+8636326f EnvMeshGeComponentDef
 e5a9c94a EnvironmentBakedLightingShadingModel
 765f0c19 EnvironmentPbrShadingModel
 0ed05709 EnvironmentUnlitShadingModel
@@ -1328,6 +1340,7 @@ b5f69929 IGameCalculationPartWithStats
 e24c8317 IGameModeConfig
 3e5051fa IGameModeConfigBase
 c03bb018 IGameModeConfigClient
+62a09c62 IGeComponentDef
 7369448b IHudLoadingScreenWidget
 f795f405 IInputSourceBool
 aba5f12d IInputSourceFloat
@@ -1612,7 +1625,9 @@ ccea6e3a LevelScriptOnReset
 562f28ea LevelScriptOnUpdate
 f30a6eea LevelUpUiData
 5dd353fa LightChannelsGeComponent
+80b13e71 LightChannelsGeComponentDef
 853d9e9a LightRegionGeComponent
+972a7491 LightRegionGeComponentDef
 2cdc6a27 LineTargetToCaster
 4388bb90 LinearTransformProcessorData
 db961a4b LinearTransformProcessorDataInstance
@@ -1966,6 +1981,7 @@ b62eaf02 ModeSelectButtonData
 61767839 ModeSelectQueueButtonData
 795e5e4f ModeSelectViewController
 94f09958 ModesScenarioGeComponent
+409452bf ModesScenarioGeComponentDef
 ce9b917b ModifiableFloat
 4379a5b2 ModifierAddedCalculationPart
 f290add3 MouseOverEffectData
@@ -1992,8 +2008,11 @@ bdc90544 NavGridConfig
 bf11c509 NavGridTerrainConfig
 b13284de NavHeaderViewController
 7866db89 NavRegionGeComponent
+4bb80830 NavRegionGeComponentDef
 0dc0043a NavigationGroup
+7a2bf6d5 NetworkingGeComponentDef
 1ced7194 NeutralCampGeComponent
+9597a7ab NeutralCampGeComponentDef
 fe7449a3 NeutralMinionCamp
 95fd84e9 NeutralMinionCampClearedLogic
 acb408c2 NeutralMinionCampCommon
@@ -2009,6 +2028,7 @@ fa3c7ffa NeutralTimerState
 4c7bb73e NeutralTimers
 05ae7109 NeutralTimersInstance
 1f91304b NewIconGeComponent
+5779866a NewIconGeComponentDef
 c3f33ef3 NewSpellCastFlowToggles
 dd681b43 NextBuffVars
 321d6e25 NextBuffVarsTable
@@ -2323,6 +2343,7 @@ a4290ed0 RegionDataBase
 6ed61477 RegionElementData
 d8f395a4 RegionEntityTemplate
 18ca230c RegionGeComponent
+b1c52813 RegionGeComponentDef
 22df6f20 RegionSettings
 9ddb195b RegionSettingsInstance
 94315a01 RegionsThatAllowContent
@@ -2435,6 +2456,7 @@ f5beca5e ScriptCheatInstance
 bd0c529d ScriptDataObjectList
 13e3455e ScriptFunction
 77a7cfc5 ScriptGeComponent
+4017248c ScriptGeComponentDef
 be608a4c ScriptGlobalProperties
 44d32cf7 ScriptGlobalPropertiesInstance
 2f787f62 ScriptPreloadCharacter
@@ -2486,6 +2508,7 @@ aaa03772 SequenceTiming
 8d30a7c0 SequencerClipData
 97287bfb SequencerClipDataInstance
 fbe6ace9 SequencerGeComponent
+1eee9d10 SequencerGeComponentDef
 6d1ee7ae SetBit
 f9caf4e5 SetInvulnerableBlock
 86e7be2a SetKeyValueInCustomTableBlock
@@ -2499,6 +2522,7 @@ fd6c74ef SetTableValueBlock
 bc67870e SetVarInTableBlock
 00f59899 SetVarInTableBlockInstance
 0a4531fd SettingsViewController
+de1e8cca SfxGeComponentDef
 14a2befa ShaderLogicalParameter
 05e3ea65 ShaderLogicalParameterInstance
 81778d13 ShaderMacroDef
@@ -2515,6 +2539,7 @@ ab0e654f ShaderSamplerDef
 a847e0a9 Shop
 57c67d10 ShopCommon
 df795218 ShopGeComponent
+20e8567f ShopGeComponentDef
 947b858f ShowObjectsCheat
 f4dc8ec5 ShowServerMissilesCheat
 e9fb4d18 SiblingStatCoefficientBySubPart
@@ -2536,6 +2561,7 @@ de28699e SkinBorderOrder
 33068165 SkinCharacterDataProperties_CharacterIdleEffect
 736b0532 SkinCharacterDataProperties_CharacterIdleEffectInstance
 9eec48aa SkinCharacterGeComponent
+aef1db01 SkinCharacterGeComponentDef
 f7fd1497 SkinCharacterMetaDataProperties
 fca49aa4 SkinCharacterMetaDataPropertiesInstance
 530b4b47 SkinCharacterMetaDataProperties_SpawningSkinOffset
@@ -2656,6 +2682,7 @@ c145a43a StatUIDataInstance
 e04f7948 StateAnimTransitionData
 c4a00944 StateLogicEventData
 0f3a3942 StateMachineGeComponent
+13e5fb09 StateMachineGeComponentDef
 e091eead StateTransitionData
 735b4c95 StaticMaterialChildTechniqueDef
 d602cea2 StaticMaterialChildTechniqueDefInstance
@@ -2872,9 +2899,11 @@ cb20c47a TargetingRangeValue
 6fb1f68f TeamFightViewController
 2b768993 TeamFramesViewController
 304c98db TeamGeComponent
+1b1b0d1a TeamGeComponentDef
 f934934d TeamScoreMeterUITunables
 6638d338 TeamScoreUiData
 eebabfce TeamSpawnPointGeComponent
+d85cb8c5 TeamSpawnPointGeComponentDef
 73dca0f0 TechniqueDef
 ac9d3cf9 TempTable
 8386aed8 TempTable1
@@ -3509,6 +3538,7 @@ b13097f0 VfxFlexShapeDefinitionData
 51d3dcdc VfxFloatOverLifeMaterialDriver
 c039d307 VfxFloatOverLifeMaterialDriverInstance
 0c7a3b52 VfxGeComponent
+82b49579 VfxGeComponentDef
 dc227f32 VfxGeometryComponent
 389424af VfxGeometryComponentBase
 88c8b7c7 VfxGroupDefinitionData
@@ -3639,6 +3669,7 @@ a2603593 WardSkinDisablerInstance
 35bd5a3e WeightedSelectionCalculator
 2dcfc13a WidthPerSecond
 d20bd7a4 WorldSpaceUiGeComponent
+3f90b51b WorldSpaceUiGeComponentDef
 b1474db1 WorldVars
 54726d4b WorldVarsTable
 8f15d6b8 WorldVarsTableInstance

--- a/hashes/lol/hashes.bintypes.txt
+++ b/hashes/lol/hashes.bintypes.txt
@@ -75,6 +75,7 @@ a39160e9 AndScriptConditionInstance
 b075bcfd AnimatedBuildingCommon
 7fc1d873 AnimationFractionDynamicMaterialFloatDriver
 2b579f70 AnimationFractionDynamicMaterialFloatDriverInstance
+6665076c AnimationGeComponent
 f5fb07c7 AnimationGraphData
 322a4094 AnimationGraphDataInstance
 9a4b299d AnimationResourceData
@@ -108,6 +109,7 @@ e6caaf8c AttackEvents
 02428ae6 AttackSlotDataInstance
 9c4f3cc3 AttackSpeedParametricUpdater
 2092043f AttackableUnit
+0ae1a932 AttackableUnitGeComponent
 865caeee AudioStatusEvents
 77c4e579 AudioStatusEventsInstance
 3692fac5 AudioSystemDataProperties
@@ -147,6 +149,7 @@ d1ed70fe Barracks
 4fbc08a8 BarracksConfig
 60bb49c0 BarracksDampener
 f10cf1d9 BarracksDampenerCommon
+63143919 BarracksGeComponent
 ffb1b62c BarracksLevelController
 8f0c2ed6 BarracksLink
 8129e422 BarracksMinionConfig
@@ -354,6 +357,7 @@ e21083b5 ChildMapVisibilityController
 64a056ca ChildMissileRepulsion
 911cbd12 ChildMissileSiblingRepulsion
 8085e5d1 CinematicBarsViewController
+bafcf76c CinematicCameraGeComponent
 039b5ebc CircleMovement
 a66643e7 CircleMovementInstance
 4a9d1e4f CircleMovementSpec
@@ -602,6 +606,7 @@ d5c6d005 DamageTypeRadialChart
 ec41779d DamageUnitCheat
 3cebd9da DamageUnitCheatInstance
 2e548aaf DeathEventPriority
+8563543c DeathGeComponent
 d09acba6 DeathRecapDamageOverview
 7efae6c2 DeathRecapDamagerCondensedList
 75e8f0c1 DeathRecapDamagerDetailedDisplayData
@@ -665,6 +670,7 @@ d232712d DisplayStatUiData
 ceaae805 DoDamage
 a1c2c89f DoubleSidedTipStyle
 0af2666c DragDirection
+b251dcda DragonCampGeComponent
 cd0d7450 DragonUITunables
 03b1c66a DrawAreaList
 42d144f5 DrawFx
@@ -673,6 +679,8 @@ b29e8d11 DrawablePositionLocatorInstance
 266089da DropRateSlot
 2d6bf1a2 DynamicMaterialDef
 8dd0b9dd DynamicMaterialDefInstance
+96974776 DynamicMaterialGeComponent
+7a12b6a7 DynamicMaterialHelper
 073f6a51 DynamicMaterialParameterDef
 d8670eee DynamicMaterialParameterDefInstance
 ef39fa85 DynamicMaterialStaticSwitch
@@ -681,6 +689,8 @@ ef39fa85 DynamicMaterialStaticSwitch
 26681a27 DynamicMaterialTextureSwapDefInstance
 21d0c864 DynamicMaterialTextureSwapOption
 3670e03f DynamicMaterialTextureSwapOptionInstance
+c02e8323 DynamicPointLightGeComponent
+de1c190d DynamicSpotlightGeComponent
 48b49195 ESportLeagueEntry
 9c1fb3a2 ESportLeagueEntryInstance
 141100a5 ESportTeamEntry
@@ -1031,6 +1041,7 @@ da5e2485 GameplayFeatureTogglesInstance
 da9e5c0c GdsMapObject
 b43441ae GearData
 f693c639 GearDataInstance
+62848e29 GearGeComponent
 361810cd GearSelectionViewController
 27dd6361 GearSkinUpgrade
 d152733e GearSkinUpgradeInstance
@@ -1073,6 +1084,7 @@ aa2b7ab2 GrassObject
 1186c725 GrassSwayIntensityParametricUpdater
 96ccf33d GravityHeightSolver
 7db7e17a GravityHeightSolverInstance
+69ea53eb GreenGeComponent
 a0406423 GroupRepeat
 7a633477 HappenedNearTurretConstraintInfo
 f7ae5e16 HasAllSubRequirementsCastRequirement
@@ -1340,6 +1352,8 @@ ecf76724 IMaterialDef
 7971fbee IOptionItem
 cb8dfbc8 IOptionItemFilter
 bc0bc533 IOptionTemplate
+f7292242 IParticleQuadShadingModel
+2393bd4d IParticleShadingModel
 ec1355b3 IPath
 0faeb4d0 IPictureInPictureSource
 9ee5e504 IRSCondition
@@ -1409,6 +1423,7 @@ d132d7b0 IVfxMaterialDriverInstance
 db6e9d8d IconElementDataExtension
 f3b028db IconElementDataInstance
 d4441c55 IconElementGradientExtension
+8fac195f IconGeComponent
 33b88aa0 IconLink
 0a450b25 IconStateData
 0a7e3f16 IdMappingEntry
@@ -1593,6 +1608,8 @@ b68a82eb LevelScriptOnLoad
 ccea6e3a LevelScriptOnReset
 562f28ea LevelScriptOnUpdate
 f30a6eea LevelUpUiData
+5dd353fa LightChannelsGeComponent
+853d9e9a LightRegionGeComponent
 2cdc6a27 LineTargetToCaster
 4388bb90 LinearTransformProcessorData
 db961a4b LinearTransformProcessorDataInstance
@@ -1793,6 +1810,7 @@ bf11ddc7 MapMaterialSwap
 1c7aba6e MapNavGrid
 e1127f16 MapNavGridOverlay
 b51e8bff MapNavGridOverlays
+cf4a55da MapNavGridOverlaysComponent
 38d3b701 MapNavigationGridOverlay
 e749c876 MapNavigationGridOverlays
 16349e22 MapNavigationMesh
@@ -1828,6 +1846,7 @@ cd19ef3c MapSkin
 d7d66467 MapSkinInstance
 d11fafa3 MapSpotlight
 adefc98e MapSpotlightBase
+1717869f MapSsao
 429f3e94 MapStaticPointLightBase
 169a2f9c MapSunProperties
 09fb9fc7 MapSunPropertiesInstance
@@ -1943,6 +1962,7 @@ ae9e709a MobileCatalogData
 b62eaf02 ModeSelectButtonData
 61767839 ModeSelectQueueButtonData
 795e5e4f ModeSelectViewController
+94f09958 ModesScenarioGeComponent
 ce9b917b ModifiableFloat
 4379a5b2 ModifierAddedCalculationPart
 f290add3 MouseOverEffectData
@@ -1968,7 +1988,9 @@ af96bb9b NamedIconData
 bdc90544 NavGridConfig
 bf11c509 NavGridTerrainConfig
 b13284de NavHeaderViewController
+7866db89 NavRegionGeComponent
 0dc0043a NavigationGroup
+1ced7194 NeutralCampGeComponent
 fe7449a3 NeutralMinionCamp
 95fd84e9 NeutralMinionCampClearedLogic
 acb408c2 NeutralMinionCampCommon
@@ -1983,6 +2005,7 @@ fa3c7ffa NeutralTimerState
 0e9b6d64 NeutralTimerViewController
 4c7bb73e NeutralTimers
 05ae7109 NeutralTimersInstance
+1f91304b NewIconGeComponent
 c3f33ef3 NewSpellCastFlowToggles
 dd681b43 NextBuffVars
 321d6e25 NextBuffVarsTable
@@ -2003,6 +2026,7 @@ eac1ad19 NotificationListItemData
 16a40caa NotificationsPanelViewController
 6f18d402 NotificationsViewController
 edb8a340 NotificationsViewPanelController
+b67bce14 NovaScoreboardViewController
 caba4f42 NudgeIntoBrush
 7a42f079 NullMovement
 042b54c6 NullMovementInstance
@@ -2121,6 +2145,11 @@ c8fbfa9f ParametricPairData
 83ec465a ParticleEventDataInstance
 5dd693f9 ParticleEventDataPair
 975fe846 ParticleEventDataPairInstance
+6cd105a4 ParticleMeshLitShadingModel
+49c67a21 ParticleMeshPbrShadingModel
+c94926c6 ParticleQuadLitShadingModel
+3d98a8d3 ParticleQuadPbrShadingModel
+66a573df ParticleQuadUnlitShadingModel
 dd7f9556 ParticleSystemElementData
 bc7980ca ParticleWadFileDescriptor
 9a619bbc PartnerGroupPlacements
@@ -2274,6 +2303,7 @@ f8ca5e60 RecallSkinUpgradeInstance
 797063e4 ReciprocityController
 bd0d6b78 RecommendedJunglePathIcons
 4e4bbc2b ReconnectDialogViewController
+b9adda8b RedGeComponent
 25167c2f RefundAbilityPointsCheat
 cc72cb1e RefundDialogViewController
 cec9c9dc RegaliaBorder
@@ -2288,6 +2318,7 @@ b574b3af RegionBoundary
 2da963dd RegionBoundaryConfig
 a4290ed0 RegionDataBase
 6ed61477 RegionElementData
+18ca230c RegionGeComponent
 22df6f20 RegionSettings
 9ddb195b RegionSettingsInstance
 94315a01 RegionsThatAllowContent
@@ -2399,6 +2430,7 @@ f5beca5e ScriptCheatInstance
 60e00531 ScriptDataObject
 bd0c529d ScriptDataObjectList
 13e3455e ScriptFunction
+77a7cfc5 ScriptGeComponent
 be608a4c ScriptGlobalProperties
 44d32cf7 ScriptGlobalPropertiesInstance
 2f787f62 ScriptPreloadCharacter
@@ -2449,6 +2481,7 @@ aaa03772 SequenceTiming
 6b258540 SequenceType
 8d30a7c0 SequencerClipData
 97287bfb SequencerClipDataInstance
+fbe6ace9 SequencerGeComponent
 6d1ee7ae SetBit
 f9caf4e5 SetInvulnerableBlock
 86e7be2a SetKeyValueInCustomTableBlock
@@ -2477,6 +2510,7 @@ ab0e654f ShaderSamplerDef
 99443cf6 ShieldParams
 a847e0a9 Shop
 57c67d10 ShopCommon
+df795218 ShopGeComponent
 947b858f ShowObjectsCheat
 f4dc8ec5 ShowServerMissilesCheat
 e9fb4d18 SiblingStatCoefficientBySubPart
@@ -2497,6 +2531,7 @@ de28699e SkinBorderOrder
 201d5d11 SkinCharacterDataPropertiesInstance
 33068165 SkinCharacterDataProperties_CharacterIdleEffect
 736b0532 SkinCharacterDataProperties_CharacterIdleEffectInstance
+9eec48aa SkinCharacterGeComponent
 f7fd1497 SkinCharacterMetaDataProperties
 fca49aa4 SkinCharacterMetaDataPropertiesInstance
 530b4b47 SkinCharacterMetaDataProperties_SpawningSkinOffset
@@ -2616,6 +2651,7 @@ c145a43a StatUIDataInstance
 8e14e9d9 StateAnimClipData
 e04f7948 StateAnimTransitionData
 c4a00944 StateLogicEventData
+0f3a3942 StateMachineGeComponent
 e091eead StateTransitionData
 735b4c95 StaticMaterialChildTechniqueDef
 d602cea2 StaticMaterialChildTechniqueDefInstance
@@ -2831,8 +2867,10 @@ cb20c47a TargetingRangeValue
 86dca50c TeamFightUiTunables
 6fb1f68f TeamFightViewController
 2b768993 TeamFramesViewController
+304c98db TeamGeComponent
 f934934d TeamScoreMeterUITunables
 6638d338 TeamScoreUiData
+eebabfce TeamSpawnPointGeComponent
 73dca0f0 TechniqueDef
 ac9d3cf9 TempTable
 8386aed8 TempTable1
@@ -2993,6 +3031,7 @@ b2c5db9d TftLobbyCustomAssets
 ae83d1c0 TftMapCharacterList
 0db03ead TftMapCharacterRecordData
 9e2461e1 TftMapCharacterSkinData
+b9b1bd74 TftMapCutsceneComponent
 851d819c TftMapGroupData
 8267ef4e TftMapItemData
 0c35fd9a TftMapItemList
@@ -3428,6 +3467,7 @@ f627e1a2 VfxAssetRemap
 1fb8df09 VfxBeamDefinitionData
 210c19d6 VfxBeamDefinitionDataInstance
 4b864aeb VfxBeamParticleDefinitionData
+5561bbca VfxChildComponent
 969aee94 VfxChildIdentifier
 b41c76af VfxChildIdentifierInstance
 b520045a VfxChildParticleSetDefinitionData
@@ -3437,6 +3477,7 @@ b520045a VfxChildParticleSetDefinitionData
 5dcc2b4e VfxColorOverLifeMaterialDriverInstance
 85b14d00 VfxComplexEmitterDefinitionData
 9b9fab12 VfxComplexParticleDefinitionData
+80d55cb7 VfxComponentBase
 49d51b69 VfxDistortionDefinitionData
 1a72ed36 VfxDistortionDefinitionDataInstance
 bfc2e133 VfxEmissionSurfaceData
@@ -3462,19 +3503,33 @@ b13097f0 VfxFlexShapeDefinitionData
 5c4922b6 VfxFloatBase
 51d3dcdc VfxFloatOverLifeMaterialDriver
 c039d307 VfxFloatOverLifeMaterialDriverInstance
+0c7a3b52 VfxGeComponent
+dc227f32 VfxGeometryComponent
+389424af VfxGeometryComponentBase
 88c8b7c7 VfxGroupDefinitionData
+a04cb2e7 VfxLegacyGeometryComponent
+32913f06 VfxLegacyLifetimeComponent
+e90140f4 VfxLegacyPhysicsComponent
+60c24094 VfxLegacyPrimitiveBase
+2ffd9a47 VfxLegacyRenderComponent
+6f07f7b3 VfxLifetimeComponent
+a9e1acbe VfxLifetimeComponentBase
 9b19f2b5 VfxLingerDefinitionData
 2820c167 VfxMaterialDefinitionData
 f9a4891f VfxMaterialOverrideDefinition
 d9b82e87 VfxMaterialOverrideDefinitionData
 d5ae0f54 VfxMaterialOverrideDefinitionDataInstance
+5301c149 VfxMaterialRenderComponent
 6a88780b VfxMeshDefinitionData
 91939378 VfxMeshDefinitionDataInstance
 823969e6 VfxMigrationResources
 1adc1d81 VfxMigrationResourcesInstance
+1fe2b3db VfxModularPhysicsComponent
 a8ad8317 VfxPaletteDefinitionData
 9ae45924 VfxPaletteDefinitionDataInstance
 12ab5c27 VfxParentInheritanceParams
+adce0266 VfxPhysicsComponentBase
+9a4cdc60 VfxPhysicsModifierBase
 4beb81fd VfxPrimitiveArbitraryQuad
 75adad3a VfxPrimitiveArbitraryQuadInstance
 27d39da0 VfxPrimitiveArbitrarySegmentBeam
@@ -3503,6 +3558,7 @@ fdd6dfa2 VfxPrimitiveCameraUnitQuad
 fc395264 VfxPrimitiveMeshBase
 7320aa3f VfxPrimitiveMeshBaseInstance
 d988ef86 VfxPrimitiveMeshInstance
+8df5fcf7 VfxPrimitiveNonRenderable
 e9945dad VfxPrimitivePlanarProjection
 14d27e2a VfxPrimitivePlanarProjectionInstance
 e4748b84 VfxPrimitiveProjectionBase
@@ -3517,6 +3573,7 @@ efd52b0a VfxPrimitiveTrailBaseInstance
 af8038c0 VfxProjectionDefinitionDataInstance
 4112ea83 VfxReflectionDefinitionData
 34d71640 VfxReflectionDefinitionDataInstance
+f0763c13 VfxRenderComponentBase
 77cf93a8 VfxShape
 ba945ee1 VfxShapeBox
 12ab94a6 VfxShapeCylinder
@@ -3529,6 +3586,7 @@ ee3bf0b0 VfxSimpleEmitterDefinitionData
 d6c3e982 VfxSineMaterialDriverInstance
 1daa3fb0 VfxSoftParticleDefinitionData
 a3c5bc6b VfxSoftParticleDefinitionDataInstance
+2324a55c VfxSpawnBehavior
 a8eb52f4 VfxSpawnConditions
 45cd899f VfxSystemDefinitionData
 71a26b5c VfxSystemDefinitionDataInstance
@@ -3575,12 +3633,14 @@ fa33b8e8 WardSkinDisabler
 a2603593 WardSkinDisablerInstance
 35bd5a3e WeightedSelectionCalculator
 2dcfc13a WidthPerSecond
+d20bd7a4 WorldSpaceUiGeComponent
 b1474db1 WorldVars
 54726d4b WorldVarsTable
 8f15d6b8 WorldVarsTableInstance
 95ef430a X3DSharedConstantBufferDef
 0125d45c X3DSharedConstantDef
 344a9a75 X3DSharedData
+429c75be X3DSharedSamplerDef
 3745189b X3DSharedTextureDef
 46d43861 iconUrl
 a2d2015e mapgeo


### PR DESCRIPTION
I found these while creating a new changelog feature for the Meta Wiki.
Strings were bruteforced using a generated wordset from the existing hashtable.
These are just a small % of the new stuff being added for reworked/updated game engine systems. Seems to be a first look at Riot's new entity/component system which might be replacing the current more concretely defined data structures along with a tease of the new PBR rendering model.
