### PR TITLE
Add CharacterOutline hashes

### DIFF
--- a/hashes/lol/hashes.binfields.txt
+++ b/hashes/lol/hashes.binfields.txt
@@ -3426,6 +3426,7 @@ a69fdb94 OutValue
 695012cc OutWasFound
 548e8cea OuterRadius
 361ad8bd Outline
+9a817954 OutlineCategorySubmeshes
 79a94f04 Output
 ae9faafb OutputMaxValue
 6129b949 OutputMinValue

--- a/hashes/lol/hashes.bintypes.txt
+++ b/hashes/lol/hashes.bintypes.txt
@@ -311,6 +311,8 @@ db69f5cb CharacterInstance
 07c20fe9 CharacterLevelRequirement
 a939f1b6 CharacterLevelRequirementInstance
 747991cb CharacterMeshGeComponentDef
+5d7c19de CharacterOutlineCategory
+993f8595 CharacterOutlineSubmeshes
 c6228969 CharacterOverrides
 8ea3ea45 CharacterPassiveData
 fc4f4b05 CharacterPreloadData


### PR DESCRIPTION
Adds 2 new class names and 1 field name related to a new rendering feature. Used with League Classic (Jade) characters to assign an outline material to specified submeshes.

<img width="842" height="256" alt="image" src="https://github.com/user-attachments/assets/4dcaec2f-0bbf-4cc6-a160-751bd16d0938" />

 *This work was done with the help of an LLM*